### PR TITLE
add ro.product.first_api_level

### DIFF
--- a/product/android.mk
+++ b/product/android.mk
@@ -1,0 +1,3 @@
+# First api level, device has been commercially launched
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.product.first_api_level=22


### PR DESCRIPTION
Add ro.product.first_api_level to declare which API level
a device first shipped with.

Issue: CRACKLING-1211
Change-Id: I101fe4384508660da711fe24e45192cb3e212477